### PR TITLE
Removed bodySite example

### DIFF
--- a/examples/transaction-0.json
+++ b/examples/transaction-0.json
@@ -198,14 +198,6 @@
       },
       "resource": {
         "collection": {
-          "bodySite": {
-            "coding": [
-              {
-                "code": "C26.8",
-                "system": "urn:oid:2.16.840.1.113883.6.43.1"
-              }
-            ]
-          },
           "collectedDateTime": "2005-06-17",
           "fastingStatusCodeableConcept": {
             "coding": [


### PR DESCRIPTION
Until the Validator can process urns, the example should be removed so it does not block the CI.