### PR TITLE
Support multiple ICD Versions

### DIFF
--- a/extension/Diagnosis.StructureDefinition.json
+++ b/extension/Diagnosis.StructureDefinition.json
@@ -17,10 +17,10 @@
   "derivation": "constraint",
   "differential": {
     "element": [
-	{
-        "id" : "Extension.url",
-        "path" : "Extension.url",
-        "fixedUri" : "https://fhir.bbmri.de/StructureDefinition/SampleDiagnosis"
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "https://fhir.bbmri.de/StructureDefinition/SampleDiagnosis"
       },
       {
         "id": "Extension.value[x]",
@@ -33,6 +33,53 @@
         "binding": {
           "strength": "required",
           "valueSet": "https://fhir.bbmri.de/ValueSet/SampleContentDiagnosis"
+        }
+      },
+      {
+        "id": "Extension.value[x].coding",
+        "path": "Extension.value[x].coding",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "system"
+            },
+            {
+              "type": "value",
+              "path": "version"
+            }
+          ],
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Extension.value[x].coding:icd-10-who",
+        "path": "Extension.value[x].coding",
+        "sliceName": "icd-10-who",
+        "binding": {
+          "strength": "required",
+          "description": "Sample Content in ICD-10 WHO or unspecific",
+          "valueSet": "https://fhir.bbmri.de/ValueSet/SampleContentDiagnosisICD-10-WHO"
+        }
+      },
+      {
+        "id": "Extension.value[x].coding:icd-10-gm",
+        "path": "Extension.value[x].coding",
+        "sliceName": "icd-10-gm",
+        "binding": {
+          "strength": "required",
+          "description": "Sample Content in ICD-10 GM or unspecific",
+          "valueSet": "https://fhir.bbmri.de/ValueSet/SampleContentDiagnosisICD-10-GM"
+        }
+      },
+      {
+        "id": "Extension.value[x].coding:icd-9",
+        "path": "Extension.value[x].coding",
+        "sliceName": "icd-9",
+        "binding": {
+          "strength": "required",
+          "description": "Sample Content in ICD-9 or unspecific",
+          "valueSet": "https://fhir.bbmri.de/ValueSet/SampleContentDiagnosisICD-9"
         }
       }
     ]

--- a/profile/Condition.StructureDefinition.json
+++ b/profile/Condition.StructureDefinition.json
@@ -42,19 +42,21 @@
         "mustSupport": true
       },
       {
-        "id": "Condition.code.coding.system",
-        "path": "Condition.code.coding.system",
-        "fixedUri": "http://hl7.org/fhir/sid/icd-10"
-      },
-      {
-        "id": "Condition.code.coding.version",
-        "path": "Condition.code.coding.version",
-        "fixedString": "2016"
-      },
-      {
-        "id": "Condition.code.coding.display",
-        "path": "Condition.code.coding.display",
-        "max": "0"
+        "id": "Condition.code.coding",
+        "path": "Condition.code.coding",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "system"
+            },
+            {
+              "type": "value",
+              "path": "version"
+            }
+          ],
+          "rules": "open"
+        }
       },
       {
         "id": "Condition.code.coding.userSelected",
@@ -62,9 +64,37 @@
         "max": "0"
       },
       {
-        "id": "Condition.code.text",
-        "path": "Condition.code.text",
-        "max": "0"
+        "id": "Condition.code.coding:icd-10-who",
+        "path": "Condition.code.coding",
+        "sliceName": "icd-10-who"
+      },
+      {
+        "id": "Condition.code.coding:icd-10-who.system",
+        "path": "Condition.code.coding.system",
+        "fixedUri": "http://hl7.org/fhir/sid/icd-10"
+      },
+      {
+        "id": "Condition.code.coding:icd-9",
+        "path": "Condition.code.coding",
+        "sliceName": "icd-9"
+      },
+      {
+        "id": "Condition.code.coding:icd-9.system",
+        "path": "Condition.code.coding.system",
+        "fixedUri": "http://hl7.org/fhir/sid/icd9"
+      },
+      {
+        "id": "Condition.code.coding:icd-10-gm",
+        "path": "Condition.code.coding",
+        "sliceName": "icd-10-gm",
+        "type": [
+          {
+            "code": "Coding",
+            "profile": [
+              "http://fhir.de/StructureDefinition/CodingICD10GM"
+            ]
+          }
+        ]
       },
       {
         "id": "Condition.bodySite",

--- a/terminology/valueset/SampleContentDiagnosisICD-10-GM.ValueSet.json
+++ b/terminology/valueset/SampleContentDiagnosisICD-10-GM.ValueSet.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "ValueSet",
+  "url": "https://fhir.bbmri.de/ValueSet/SampleContentDiagnosisICD-10-GM",
+  "name": "SampleContentDiagnosisICD-10-GM",
+  "title": "sample content diagnosis ICD-10-GM",
+  "status": "draft",
+  "compose": {
+    "include": [
+      {
+        "system": "https://fhir.bbmri.de/CodeSystem/OtherSampleDiagnosis"
+      },
+      {
+        "system": "http://fhir.de/CodeSystem/dimdi/icd-10-gm"
+      }
+    ]
+  }
+}

--- a/terminology/valueset/SampleContentDiagnosisICD-10-WHO.ValueSet.json
+++ b/terminology/valueset/SampleContentDiagnosisICD-10-WHO.ValueSet.json
@@ -1,8 +1,8 @@
 {
   "resourceType": "ValueSet",
-  "url": "https://fhir.bbmri.de/ValueSet/SampleContentDiagnosis",
-  "name": "SampleContentDiagnosis",
-  "title": "sample content diagnosis",
+  "url": "https://fhir.bbmri.de/ValueSet/SampleContentDiagnosisICD-10-WHO",
+  "name": "SampleContentDiagnosisICD-10-WHO",
+  "title": "sample content diagnosis ICD-10-WHO",
   "status": "draft",
   "compose": {
     "include": [

--- a/terminology/valueset/SampleContentDiagnosisICD-9.ValueSet.json
+++ b/terminology/valueset/SampleContentDiagnosisICD-9.ValueSet.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "ValueSet",
+  "url": "https://fhir.bbmri.de/ValueSet/SampleContentDiagnosisICD-9",
+  "name": "SampleContentDiagnosisICD-9",
+  "title": "sample content diagnosis ICD-9",
+  "status": "draft",
+  "compose": {
+    "include": [
+      {
+        "system": "https://fhir.bbmri.de/CodeSystem/OtherSampleDiagnosis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd9"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
In Condition and SampleDiagnosis Extension, make it possible to use ICD-10-WHO, ICD-10-GM and ICD-9 (also in different year versions).